### PR TITLE
DarkMode: various dark-mode fixes

### DIFF
--- a/app/Support/Spotlight.php
+++ b/app/Support/Spotlight.php
@@ -19,7 +19,7 @@ class Spotlight
 
     public function actions(string $search = ''): Collection
     {
-        $icon = Blade::render("<x-mary-icon name='o-bolt' class='w-11 h-11 p-2 bg-yellow-50 rounded-full' />");
+        $icon = Blade::render("<x-mary-icon name='o-bolt' class='w-11 h-11 p-2 bg-yellow-500/10 rounded-full' />");
 
         return collect([
             [

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -28,7 +28,7 @@ p {
 }
 
 .landing pre {
-    @apply !mt-0
+    @apply !my-0
 }
 
 /* Hide elements from <x-code> component when necessary */

--- a/resources/views/livewire/docs/components/avatar.blade.php
+++ b/resources/views/livewire/docs/components/avatar.blade.php
@@ -49,7 +49,7 @@ class extends Component {
                     {{ $user->username }}
                 </x-slot:title>
 
-                <x-slot:subtitle class="text-neutral dark:text-neutral-content flex flex-col gap-1 mt-2 pl-2">
+                <x-slot:subtitle class="text-gray-500 flex flex-col gap-1 mt-2 pl-2">
                     <x-icon name="o-paper-airplane" label="12 posts" />
                     <x-icon name="o-chat-bubble-left" label="45 comments" />
                 </x-slot:subtitle>

--- a/resources/views/livewire/docs/components/avatar.blade.php
+++ b/resources/views/livewire/docs/components/avatar.blade.php
@@ -49,7 +49,7 @@ class extends Component {
                     {{ $user->username }}
                 </x-slot:title>
 
-                <x-slot:subtitle class="text-neutral flex flex-col gap-1 mt-2 pl-2">
+                <x-slot:subtitle class="text-neutral dark:text-neutral-content flex flex-col gap-1 mt-2 pl-2">
                     <x-icon name="o-paper-airplane" label="12 posts" />
                     <x-icon name="o-chat-bubble-left" label="45 comments" />
                 </x-slot:subtitle>

--- a/resources/views/livewire/docs/components/badges.blade.php
+++ b/resources/views/livewire/docs/components/badges.blade.php
@@ -23,7 +23,7 @@ class extends Component {
 
             <x-badge value="Hello" class="badge-warning" />
 
-            <x-badge value="Hello" class="bg-cyan-200" />
+            <x-badge value="Hello" class="bg-cyan-200 dark:text-black" />
         @endverbatim
     </x-code>
 

--- a/resources/views/livewire/docs/components/badges.blade.php
+++ b/resources/views/livewire/docs/components/badges.blade.php
@@ -23,7 +23,7 @@ class extends Component {
 
             <x-badge value="Hello" class="badge-warning" />
 
-            <x-badge value="Hello" class="bg-cyan-200 dark:text-black" />
+            <x-badge value="Hello" class="bg-purple-500/10 " />
         @endverbatim
     </x-code>
 

--- a/resources/views/livewire/docs/components/menu.blade.php
+++ b/resources/views/livewire/docs/components/menu.blade.php
@@ -73,7 +73,7 @@ class extends Component {
 
     <x-code class="grid gap-5 justify-center">
         @verbatim('docs')
-            <x-menu active-bg-color="bg-blue-50 dark:bg-blue-500/10" class="border border-dashed">
+            <x-menu active-bg-color="bg-purple-500/10" class="border border-dashed">
                 {{-- Notice `active` --}}
                 <x-menu-item title="Hi" active />
                 <x-menu-item title="Some style" class="text-purple-500 font-bold" />

--- a/resources/views/livewire/docs/components/menu.blade.php
+++ b/resources/views/livewire/docs/components/menu.blade.php
@@ -73,7 +73,7 @@ class extends Component {
 
     <x-code class="grid gap-5 justify-center">
         @verbatim('docs')
-            <x-menu active-bg-color="bg-blue-50" class="border border-dashed">
+            <x-menu active-bg-color="bg-blue-50 dark:bg-blue-500/10" class="border border-dashed">
                 {{-- Notice `active` --}}
                 <x-menu-item title="Hi" active />
                 <x-menu-item title="Some style" class="text-purple-500 font-bold" />

--- a/resources/views/livewire/docs/components/steps.blade.php
+++ b/resources/views/livewire/docs/components/steps.blade.php
@@ -67,14 +67,14 @@ class extends Component {
 
     <x-code>
         @verbatim('docs')
-            <x-steps wire:model="step" class="border my-5 p-5">
+            <x-steps wire:model="step" class="border border-base-content/25 my-5 p-5">
                 <x-step step="1" text="Register">
                     Register step
                 </x-step>
                 <x-step step="2" text="Payment">
                     Payment step
                 </x-step>
-                <x-step step="3" text="Receive Product" class="bg-orange-100">
+                <x-step step="3" text="Receive Product" class="bg-orange-100 dark:bg-orange-500/20">
                     Receive Product
                 </x-step>
             </x-steps>

--- a/resources/views/livewire/docs/components/steps.blade.php
+++ b/resources/views/livewire/docs/components/steps.blade.php
@@ -67,14 +67,14 @@ class extends Component {
 
     <x-code>
         @verbatim('docs')
-            <x-steps wire:model="step" class="border border-base-content/25 my-5 p-5">
+            <x-steps wire:model="step" class="border my-5 p-5">
                 <x-step step="1" text="Register">
                     Register step
                 </x-step>
                 <x-step step="2" text="Payment">
                     Payment step
                 </x-step>
-                <x-step step="3" text="Receive Product" class="bg-orange-100 dark:bg-orange-500/20">
+                <x-step step="3" text="Receive Product" class="bg-orange-500/20">
                     Receive Product
                 </x-step>
             </x-steps>

--- a/resources/views/livewire/docs/components/table.blade.php
+++ b/resources/views/livewire/docs/components/table.blade.php
@@ -140,7 +140,7 @@ class extends Component {
                 $users = User::take(3)->get();
 
                 $headers = [
-                    ['key' => 'id', 'label' => '#', 'class' => 'bg-red-100 dark:bg-red-500/20 w-1'],
+                    ['key' => 'id', 'label' => '#', 'class' => 'bg-red-500/20 w-1'],
                     ['key' => 'username', 'label' => 'Username'],
                     ['key' => 'email', 'label' => 'E-mail', 'class' => 'hidden lg:table-cell'],
                 ];
@@ -185,7 +185,7 @@ class extends Component {
                 // If more than one condition is `true` the respective classes will be merged.
 
                 $row_decoration = [
-                    'bg-yellow-100 dark:bg-yellow-500/25' => fn(User $user) => $user->isAdmin,
+                    'bg-yellow-500/25' => fn(User $user) => $user->isAdmin,
                     'text-red-500' => fn(User $user) => $user->isAdmin && $user->isInactive,
                     'underline font-bold' => fn(User $user) => $user->isInactive // <-- combined classes
                 ];
@@ -227,11 +227,11 @@ class extends Component {
 
                 $cell_decoration = [
                     'city.name' => [
-                        'bg-yellow-100 dark:bg-yellow-500/25 underline' => fn(User $user) => !$user->city->isAvailable,
+                        'bg-yellow-500/25 underline' => fn(User $user) => !$user->city->isAvailable,
                     ],
                     'username' => [
                         'text-yellow-500' => fn(User $user) => $user->isAdmin,
-                        'bg-gray-500 dark:bg-dark-300' => fn(User $user) => $user->isInactive
+                        'bg-dark-300' => fn(User $user) => $user->isInactive
                     ]
                 ];
             @endphp
@@ -452,7 +452,7 @@ class extends Component {
                 $users = App\Models\User::with('city')->take(2)->get();
 
                 $headers = [
-                    ['key' => 'id', 'label' => '#', 'class' => 'bg-red-100 dark:bg-red-500/20'], # <--- custom CSS
+                    ['key' => 'id', 'label' => '#', 'class' => 'bg-red-500/20'], # <--- custom CSS
                     ['key' => 'name', 'label' => 'Nice Name'],
                     ['key' => 'city.name', 'label' => 'City'], # <---- nested attributes
                 ];

--- a/resources/views/livewire/docs/components/table.blade.php
+++ b/resources/views/livewire/docs/components/table.blade.php
@@ -140,7 +140,7 @@ class extends Component {
                 $users = User::take(3)->get();
 
                 $headers = [
-                    ['key' => 'id', 'label' => '#', 'class' => 'bg-red-100 w-1'],
+                    ['key' => 'id', 'label' => '#', 'class' => 'bg-red-100 dark:bg-red-500/20 w-1'],
                     ['key' => 'username', 'label' => 'Username'],
                     ['key' => 'email', 'label' => 'E-mail', 'class' => 'hidden lg:table-cell'],
                 ];
@@ -185,7 +185,7 @@ class extends Component {
                 // If more than one condition is `true` the respective classes will be merged.
 
                 $row_decoration = [
-                    'bg-yellow-100' => fn(User $user) => $user->isAdmin,
+                    'bg-yellow-100 dark:bg-yellow-500/25' => fn(User $user) => $user->isAdmin,
                     'text-red-500' => fn(User $user) => $user->isAdmin && $user->isInactive,
                     'underline font-bold' => fn(User $user) => $user->isInactive // <-- combined classes
                 ];
@@ -227,11 +227,11 @@ class extends Component {
 
                 $cell_decoration = [
                     'city.name' => [
-                        'bg-yellow-100 underline' => fn(User $user) => !$user->city->isAvailable,
+                        'bg-yellow-100 dark:bg-yellow-500/25 underline' => fn(User $user) => !$user->city->isAvailable,
                     ],
                     'username' => [
                         'text-yellow-500' => fn(User $user) => $user->isAdmin,
-                        'bg-gray-500' => fn(User $user) => $user->isInactive
+                        'bg-gray-500 dark:bg-dark-300' => fn(User $user) => $user->isInactive
                     ]
                 ];
             @endphp
@@ -452,7 +452,7 @@ class extends Component {
                 $users = App\Models\User::with('city')->take(2)->get();
 
                 $headers = [
-                    ['key' => 'id', 'label' => '#', 'class' => 'bg-red-100'], # <--- custom CSS
+                    ['key' => 'id', 'label' => '#', 'class' => 'bg-red-100 dark:bg-red-500/20'], # <--- custom CSS
                     ['key' => 'name', 'label' => 'Nice Name'],
                     ['key' => 'city.name', 'label' => 'City'], # <---- nested attributes
                 ];

--- a/resources/views/pages/index.blade.php
+++ b/resources/views/pages/index.blade.php
@@ -357,7 +357,7 @@ new #[Layout('components.layouts.landing')] class extends Component {
                     $users = User::with('city')->take(4)->get();
 
                     $headers = [
-                        ['key' => 'id', 'label' => '#', 'class' => 'w-1 bg-yellow-50'], # <-- CSS
+                        ['key' => 'id', 'label' => '#', 'class' => 'w-1 bg-yellow-50 dark:bg-yellow-500/20'], # <-- CSS
                         ['key' => 'name', 'label' => 'Nice Name', 'class' => 'hidden lg:table-cell'], # <-- responsive
                         ['key' => 'city.name', 'label' => 'City']   # <-- nested object
                     ];
@@ -397,7 +397,7 @@ new #[Layout('components.layouts.landing')] class extends Component {
 
                     $cell_decoration = [
                         'name' => [
-                            'bg-yellow-50 italic' => fn(User $user) => Str::of($user->name)->startsWith('A')
+                            'bg-yellow-50 dark:bg-yellow-500/20 italic' => fn(User $user) => Str::of($user->name)->startsWith('A')
                         ]
                     ];
                 @endphp

--- a/resources/views/pages/index.blade.php
+++ b/resources/views/pages/index.blade.php
@@ -357,7 +357,7 @@ new #[Layout('components.layouts.landing')] class extends Component {
                     $users = User::with('city')->take(4)->get();
 
                     $headers = [
-                        ['key' => 'id', 'label' => '#', 'class' => 'w-1 bg-yellow-50 dark:bg-yellow-500/20'], # <-- CSS
+                        ['key' => 'id', 'label' => '#', 'class' => 'w-1 bg-yellow-500/20'], # <-- CSS
                         ['key' => 'name', 'label' => 'Nice Name', 'class' => 'hidden lg:table-cell'], # <-- responsive
                         ['key' => 'city.name', 'label' => 'City']   # <-- nested object
                     ];
@@ -397,7 +397,7 @@ new #[Layout('components.layouts.landing')] class extends Component {
 
                     $cell_decoration = [
                         'name' => [
-                            'bg-yellow-50 dark:bg-yellow-500/20 italic' => fn(User $user) => Str::of($user->name)->startsWith('A')
+                            'bg-yellow-500/20 italic' => fn(User $user) => Str::of($user->name)->startsWith('A')
                         ]
                     ];
                 @endphp


### PR DESCRIPTION
I've update the website to reflect a clean dark mode 😃 

- fix landing pre bottom margin
- fix avatar subtitle color
- fix badge text color (cyan badge)
- fix table custom bg colors
- fix menu custom active bg color
- fix spotlight bg color
- fix steps border & bg color


Let me know if you want some screenshots to compare the before and after.