### PR TITLE
fix: typo in placeholder value

### DIFF
--- a/resources/views/livewire/docs/components/select.blade.php
+++ b/resources/views/livewire/docs/components/select.blade.php
@@ -74,7 +74,7 @@ class extends Component {
                 :options="$users"
                 option-value="custom_key"
                 option-label="other_name"
-                placeholder="Select an user"
+                placeholder="Select a user"
                 placeholder-value="0" {{-- Set a value for placeholder. Default is `null` --}}
                 hint="Select one, please."
                 wire:model="selectedUser2" />


### PR DESCRIPTION
While casually reading the doc I stumbled upon this simple typo. So yeah, here's a simple PR fixing it :wink:.