### PR TITLE
feat: add ApiGenerator component and integrate it

### DIFF
--- a/app/View/Components/ApiGenerator.php
+++ b/app/View/Components/ApiGenerator.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\View\Components;
+
+use Illuminate\Support\Str;
+use Illuminate\View\Component;
+
+class ApiGenerator extends Component
+{
+    public string $className;
+    public string $title;
+    public array  $propsHeader = [
+        ['key' => 'prop', 'label' => 'Prop'],
+        ['key' => 'description', 'label' => 'Description'],
+        ['key' => 'type', 'label' => 'Type'],
+        ['key' => 'default', 'label' => 'Default'],
+        ['key' => 'required', 'label' => 'Required'],
+    ];
+
+    public array $slotsHeader = [
+        ['key' => 'slot', 'label' => 'Slot'],
+        ['key' => 'description', 'label' => 'Description'],
+    ];
+
+    public array $propsData = [];
+    public array $slotsData = [];
+
+    public function __construct(string $className)
+    {
+        $this->className = $className;
+    }
+
+    public function getHeaders(): array
+    {
+        return [
+            'props' => [
+                ['key' => 'prop', 'label' => 'Prop'],
+                ['key' => 'type', 'label' => 'Type'],
+                ['key' => 'default', 'label' => 'Default'],
+                ['key' => 'required', 'label' => 'Required'],
+            ],
+        ];
+    }
+
+    public function render()
+    {
+        $this->generateApi();
+
+        return <<<'blade'
+            <x-card title="{{ $title }} API" class="mb-5 border border-base-300" shadow>
+                <x-tabs selected="props">
+                    <x-tab name="props" label="Props">
+                        <x-table :headers="$propsHeader" :rows="$propsData" no-hover>
+                            @scope('cell_prop', $prop)
+                            <code>{{ $prop['prop'] }}</code>
+                            @endscope
+                        </x-table>
+                    </x-tab>
+                    @if(!empty($slotsData))
+                    <x-tab name="slots" label="Slots">
+                        <x-table :headers="$slotsHeader" :rows="$slotsData">
+                            @scope('cell_slot', $slot)
+                            <code>{{ $slot['slot'] }}</code>
+                            @endscope
+                        </x-table>
+                    </x-tab>
+                    @endif
+                </x-tabs>
+            </x-card>
+            blade;
+    }
+
+    public function generateApi(): void
+    {
+        $reflection  = new \ReflectionClass($this->className);
+        $this->title = Str::headline(class_basename($reflection->getName()));
+        $constructor = $reflection->getConstructor();
+
+        if (!$constructor) {
+            throw new \RuntimeException("The constructor for class {$this->className} was not found.");
+        }
+
+        $docComment = $constructor->getDocComment();
+        $docData    = $this->parseDocBlock($docComment);
+        $parameters = $constructor->getParameters();
+
+        foreach ($parameters as $param) {
+            $name     = $param->getName();
+            $type     = $param->hasType() ? $param->getType()->getName() : 'mixed';
+            $default  = $param->isDefaultValueAvailable() ? var_export($param->getDefaultValue(), true) : 'N/A';
+            $required = $param->isOptional() ? 'false' : 'true';
+
+            if (array_key_exists($name, $docData['slots'])) {
+                $this->slotsData[] = [
+                    'slot'        => $name,
+                    'description' => $docData['slots'][$name] ?? 'Slot dynamic content',
+                ];
+            }
+
+            if (array_key_exists($name, $docData['params'])) {
+                $this->propsData[] = [
+                    'prop'        => $name,
+                    'description' => $docData['params'][$name] ?? '',
+                    'type'        => $type,
+                    'default'     => $default,
+                    'required'    => $required,
+                ];
+            }
+        }
+    }
+
+    protected function parseDocBlock(?string $docComment): array
+    {
+        $parsed = ['params' => [], 'slots' => []];
+
+        if (!$docComment) {
+            return $parsed;
+        }
+
+        $lines = explode("\n", $docComment);
+        foreach ($lines as $line) {
+            $line = trim($line, " *");
+
+            if (str_starts_with($line, '@param')) {
+                preg_match('/@param\s+(\S+)\s+\$(\w+)\s+(.+)/', $line, $matches);
+                if ($matches) {
+                    $parsed['params'][$matches[2]] = $matches[3];
+                }
+            }
+
+            if (str_starts_with($line, '@slot')) {
+                preg_match('/@slot\s+(\S+)\s+\$(\w+)\s+(.+)/', $line, $matches);
+                if ($matches) {
+                    $parsed['slots'][$matches[2]] = $matches[3];
+                }
+            }
+        }
+
+        return $parsed;
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -4042,16 +4042,16 @@
         },
         {
             "name": "robsontenorio/mary",
-            "version": "1.41.0",
+            "version": "1.41.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/robsontenorio/mary.git",
-                "reference": "fe3331003bf821dcaedb58a7e2c7e9743a342762"
+                "reference": "88fc4748fd000c5201781751f1cb385142b9132b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/robsontenorio/mary/zipball/fe3331003bf821dcaedb58a7e2c7e9743a342762",
-                "reference": "fe3331003bf821dcaedb58a7e2c7e9743a342762",
+                "url": "https://api.github.com/repos/robsontenorio/mary/zipball/88fc4748fd000c5201781751f1cb385142b9132b",
+                "reference": "88fc4748fd000c5201781751f1cb385142b9132b",
                 "shasum": ""
             },
             "require": {
@@ -4117,7 +4117,7 @@
             ],
             "support": {
                 "issues": "https://github.com/robsontenorio/mary/issues",
-                "source": "https://github.com/robsontenorio/mary/tree/1.41.0"
+                "source": "https://github.com/robsontenorio/mary/tree/1.41.1"
             },
             "funding": [
                 {
@@ -4125,7 +4125,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-10-16T19:34:07+00:00"
+            "time": "2024-10-17T19:06:18+00:00"
         },
         {
             "name": "symfony/clock",

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -23,7 +23,7 @@ p {
     @apply link
 }
 
-.docs .mockup a, .docs .mary-header-anchor a {
+.docs .mockup a, .docs .mary-header-anchor a, .api-generator a {
     @apply !no-underline
 }
 

--- a/resources/views/livewire/docs/components/alert.blade.php
+++ b/resources/views/livewire/docs/components/alert.blade.php
@@ -7,18 +7,17 @@ use Livewire\Volt\Component;
 new
 #[Title('Alert')]
 #[Layout('components.layouts.app', ['description' => 'Livewire UI alert component with icon and customizable slots.'])]
-class extends Component {
-}
+class extends Component {}
 ?>
 
 <div class="docs">
-    <x-anchor title="Alert" />
+    <x-anchor title="Alert"/>
 
     <x-code class="grid gap-5">
         @verbatim('docs')
-            <x-alert title="You have 10 messages" icon="o-exclamation-triangle" />
+            <x-alert title="You have 10 messages" icon="o-exclamation-triangle"/>
 
-            <x-alert title="Hey!" description="Ho!" icon="o-home" class="alert-warning" />
+            <x-alert title="Hey!" description="Ho!" icon="o-home" class="alert-warning"/>
 
             <x-alert icon="o-exclamation-triangle" class="alert-success">
                 I am using the <strong>default slot.</strong>
@@ -26,13 +25,15 @@ class extends Component {
 
             <x-alert title="With actions" description="Hi" icon="o-envelope" class="alert-info">
                 <x-slot:actions>
-                    <x-button label="See" />
+                    <x-button label="See"/>
                 </x-slot:actions>
             </x-alert>
 
-            <x-alert title="I have a shadow" icon="o-exclamation-triangle" shadow />
+            <x-alert title="I have a shadow" icon="o-exclamation-triangle" shadow/>
 
-            <x-alert title="Dismissible" description="Click the close icon" icon="o-exclamation-triangle" dismissible />
+            <x-alert title="Dismissible" description="Click the close icon" icon="o-exclamation-triangle" dismissible/>
         @endverbatim
     </x-code>
+
+    <x-api-generator :class-name="\Mary\View\Components\Alert::class"/>
 </div>

--- a/resources/views/livewire/docs/components/alert.blade.php
+++ b/resources/views/livewire/docs/components/alert.blade.php
@@ -3,21 +3,23 @@
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Title;
 use Livewire\Volt\Component;
+use Mary\View\Components\Alert;
 
 new
 #[Title('Alert')]
 #[Layout('components.layouts.app', ['description' => 'Livewire UI alert component with icon and customizable slots.'])]
-class extends Component {}
+class extends Component {
+}
 ?>
 
 <div class="docs">
-    <x-anchor title="Alert"/>
+    <x-anchor title="Alert" />
 
     <x-code class="grid gap-5">
         @verbatim('docs')
-            <x-alert title="You have 10 messages" icon="o-exclamation-triangle"/>
+            <x-alert title="You have 10 messages" icon="o-exclamation-triangle" />
 
-            <x-alert title="Hey!" description="Ho!" icon="o-home" class="alert-warning"/>
+            <x-alert title="Hey!" description="Ho!" icon="o-home" class="alert-warning" />
 
             <x-alert icon="o-exclamation-triangle" class="alert-success">
                 I am using the <strong>default slot.</strong>
@@ -25,15 +27,18 @@ class extends Component {}
 
             <x-alert title="With actions" description="Hi" icon="o-envelope" class="alert-info">
                 <x-slot:actions>
-                    <x-button label="See"/>
+                    <x-button label="See" />
                 </x-slot:actions>
             </x-alert>
 
-            <x-alert title="I have a shadow" icon="o-exclamation-triangle" shadow/>
+            <x-alert title="I have a shadow" icon="o-exclamation-triangle" shadow />
 
-            <x-alert title="Dismissible" description="Click the close icon" icon="o-exclamation-triangle" dismissible/>
+            <x-alert title="Dismissible" description="Click the close icon" icon="o-exclamation-triangle" dismissible />
         @endverbatim
     </x-code>
 
-    <x-api-generator :class-name="\Mary\View\Components\Alert::class"/>
+    <hr class="my-10" />
+    <x-anchor title="API" size="text-2xl" class="mt-10 mb-5" />
+    <x-api-generator :class-name="Alert::class" />
+    <div class="mb-64"></div>
 </div>

--- a/resources/views/livewire/docs/components/avatar.blade.php
+++ b/resources/views/livewire/docs/components/avatar.blade.php
@@ -13,7 +13,7 @@ class extends Component {
 }; ?>
 
 <div class="docs">
-    <x-anchor title="Avatar" />
+    <x-anchor title="Avatar"/>
 
     <x-code class="grid lg:grid-cols-2 gap-8">
         @verbatim('docs')
@@ -21,21 +21,21 @@ class extends Component {
                 $user = App\Models\User::first();
             @endphp
 
-            <x-avatar :image="$user->avatar" />
+            <x-avatar :image="$user->avatar"/>
 
             {{-- Manipulate avatar imagem with CSS classes --}}
-            <x-avatar :image="$user->avatar" class="!w-14 !rounded-lg" />
+            <x-avatar :image="$user->avatar" class="!w-14 !rounded-lg"/>
 
             {{-- Title --}}
-            <x-avatar :image="$user->avatar" :title="$user->username" />
+            <x-avatar :image="$user->avatar" :title="$user->username"/>
 
             {{-- Subtitle --}}
-            <x-avatar :image="$user->avatar" :title="$user->username" :subtitle="$user->name" class="!w-10 " />
+            <x-avatar :image="$user->avatar" :title="$user->username" :subtitle="$user->name" class="!w-10 "/>
 
         @endverbatim
     </x-code>
 
-    <x-anchor title="Slots" size="text-2xl" class="mt-10 mb-5" />
+    <x-anchor title="Slots" size="text-2xl" class="mt-10 mb-5"/>
 
     <x-code class="flex gap-5">
         @verbatim('docs')
@@ -50,11 +50,13 @@ class extends Component {
                 </x-slot:title>
 
                 <x-slot:subtitle class="text-gray-500 flex flex-col gap-1 mt-2 pl-2">
-                    <x-icon name="o-paper-airplane" label="12 posts" />
-                    <x-icon name="o-chat-bubble-left" label="45 comments" />
+                    <x-icon name="o-paper-airplane" label="12 posts"/>
+                    <x-icon name="o-chat-bubble-left" label="45 comments"/>
                 </x-slot:subtitle>
 
             </x-avatar>
         @endverbatim
     </x-code>
+
+    <x-api-generator :class-name="\Mary\View\Components\Avatar::class"/>
 </div>

--- a/resources/views/livewire/docs/components/avatar.blade.php
+++ b/resources/views/livewire/docs/components/avatar.blade.php
@@ -4,6 +4,7 @@ use App\Models\User;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Title;
 use Livewire\Volt\Component;
+use Mary\View\Components\Avatar;
 
 new
 #[Title('Avatar')]
@@ -13,7 +14,7 @@ class extends Component {
 }; ?>
 
 <div class="docs">
-    <x-anchor title="Avatar"/>
+    <x-anchor title="Avatar" />
 
     <x-code class="grid lg:grid-cols-2 gap-8">
         @verbatim('docs')
@@ -21,21 +22,21 @@ class extends Component {
                 $user = App\Models\User::first();
             @endphp
 
-            <x-avatar :image="$user->avatar"/>
+            <x-avatar :image="$user->avatar" />
 
             {{-- Manipulate avatar imagem with CSS classes --}}
-            <x-avatar :image="$user->avatar" class="!w-14 !rounded-lg"/>
+            <x-avatar :image="$user->avatar" class="!w-14 !rounded-lg" />
 
             {{-- Title --}}
-            <x-avatar :image="$user->avatar" :title="$user->username"/>
+            <x-avatar :image="$user->avatar" :title="$user->username" />
 
             {{-- Subtitle --}}
-            <x-avatar :image="$user->avatar" :title="$user->username" :subtitle="$user->name" class="!w-10 "/>
+            <x-avatar :image="$user->avatar" :title="$user->username" :subtitle="$user->name" class="!w-10 " />
 
         @endverbatim
     </x-code>
 
-    <x-anchor title="Slots" size="text-2xl" class="mt-10 mb-5"/>
+    <x-anchor title="Slots" size="text-2xl" class="mt-10 mb-5" />
 
     <x-code class="flex gap-5">
         @verbatim('docs')
@@ -50,13 +51,16 @@ class extends Component {
                 </x-slot:title>
 
                 <x-slot:subtitle class="text-gray-500 flex flex-col gap-1 mt-2 pl-2">
-                    <x-icon name="o-paper-airplane" label="12 posts"/>
-                    <x-icon name="o-chat-bubble-left" label="45 comments"/>
+                    <x-icon name="o-paper-airplane" label="12 posts" />
+                    <x-icon name="o-chat-bubble-left" label="45 comments" />
                 </x-slot:subtitle>
 
             </x-avatar>
         @endverbatim
     </x-code>
 
-    <x-api-generator :class-name="\Mary\View\Components\Avatar::class"/>
+    <hr class="my-10" />
+    <x-anchor title="API" size="text-2xl" class="mt-10 mb-5" />
+    <x-api-generator :class-name="Avatar::class" />
+    <div class="mb-64"></div>
 </div>


### PR DESCRIPTION
- Created ApiGenerator component to generate API documentation for components.
- Updated 'avatar' and 'alert' blade views to utilize the new ApiGenerator component.
- Minor style fixes in blade views by removing spaces before closing tags.

Need to add docblock in the class constructor:

```
class Alert extends Component
{
    public string $uuid;

    /**
     * Alert constructor.
     *
     * @param ?string  $title  The title of the alert, displayed in bold.
     * @param ?string  $icon  The icon displayed at the beginning of the alert.
     * @param ?string  $description  A short description under the title.
     * @param ?bool  $shadow  Whether to apply a shadow effect to the alert.
     * @param ?bool  $dismissible  Whether the alert can be dismissed by the user.
     * @slot  mixed  $actions  Slots for actionable elements like buttons or links.
     */
    public function __construct(
        public ?string $title = null,
        public ?string $icon = null,
        public ?string $description = null,
        public ?bool $shadow = false,
        public ?bool $dismissible = false,

        // Slots
        public mixed $actions = null
    ) {
        $this->uuid = "mary" . md5(serialize($this));
    }
```   

```php
    /**
     * Avatar Component
     *
     * This component is responsible for displaying an avatar image
     * with optional title and subtitle content.
     *
     * @param  string|null  $image  The URL of the avatar image.
     * @param  string|null  $title  The title text displayed beside the avatar.
     * @slot  string|null  $title  The title text displayed beside the avatar.
     * @param  string|null  $subtitle  The subtitle text displayed beside the avatar.
     * @slot  string|null  $subtitle The subtitle text displayed beside the avatar.
     */
```

