### PR TITLE
Fix typo in markdown docs

### DIFF
--- a/resources/views/livewire/docs/components/markdown.blade.php
+++ b/resources/views/livewire/docs/components/markdown.blade.php
@@ -81,7 +81,7 @@ class extends Component {
 
     <x-code no-render>
         @verbatim('docs')
-            <x-editor ... disk="s3" folder="super/cool/images" />
+            <x-markdown ... disk="s3" folder="super/cool/images" />
         @endverbatim
     </x-code>
 


### PR DESCRIPTION
The example in upload settings section of markdown component docs uses `x-editor`. This PR changes that to `x-markdown`.