### PR TITLE
FEATURE | icon-classes available for Menu and Dropdown components

### DIFF
--- a/resources/views/livewire/docs/components/dropdown.blade.php
+++ b/resources/views/livewire/docs/components/dropdown.blade.php
@@ -125,6 +125,17 @@ class extends Component {
         @endverbatim
     </x-code>
 
+    <x-anchor title="Icon Classes" size="text-2xl" class="mt-10 mb-5" />
+
+    <x-code>
+        @verbatim('docs')
+            <x-dropdown label="Settings" class="btn-outline">
+                <x-menu-item title="Custom Icon Classes" icon="bi.bell-fill" icon-classes="w-9 h-9 text-blue-600"/>
+                <x-menu-item title="Custom Icon Classes" icon="bi.bell-fill" />
+            </x-dropdown>
+        @endverbatim
+    </x-code>
+
     <x-anchor title="No anchor" size="text-2xl" class="mt-10 mb-5" />
 
     <p>

--- a/resources/views/livewire/docs/components/menu.blade.php
+++ b/resources/views/livewire/docs/components/menu.blade.php
@@ -201,6 +201,29 @@ class extends Component {
         @endverbatim
     </x-code>
 
+    
+    <x-anchor title="Icon Classes" size="text-2xl" class="mt-10 mb-5" />
+    
+    <p>
+        The <code>icon-classes</code> is available for:
+        <ul>
+            <li><code>x-menu-item</code></li>
+            <li><code>x-menu-separator</code></li>
+            <li><code>x-menu-sub</code></li>
+            <li><code>x-menu-title</code></li>
+        </ul>
+    </p>
+    
+    <x-code class="grid gap-5 justify-center">
+        @verbatim('docs')
+            <x-menu class="border border-dashed">
+                <x-menu-item icon="o-chart-pie" icon-classes="w-9 h-9 text-blue-600">
+                    Custom Icon Classes
+                </x-menu-item>
+            </x-menu>
+        @endverbatim
+    </x-code>
+
     <x-anchor title="Cloud providers" size="text-2xl" class="mt-10 mb-5" />
 
     <p>


### PR DESCRIPTION
This feature allows you to add the class to icon to the following components:

- Dropdown
- Menu
   x-menu-item
   x-menu-separator
   x-menu-sub
    x-menu-title

This PR is related to: https://github.com/robsontenorio/mary/pull/716