### PR TITLE
Add object-contain to logos on homepage

### DIFF
--- a/resources/views/pages/index.blade.php
+++ b/resources/views/pages/index.blade.php
@@ -106,10 +106,10 @@ new #[Layout('components.layouts.landing')] class extends Component {
             {{--            </span>--}}
 
             <div class="flex gap-5 justify-center items-center my-10">
-                <img src="/laravel.png" class="w-12 h-12" />
-                <img src="/livewire.png" class="w-13 h-11" />
-                <img src="/tailwind.png" class="w-13 h-11" />
-                <img src="/daisy.png" class="w-9 h-12" />
+                <img src="/laravel.png" class="object-contain w-12 h-12" />
+                <img src="/livewire.png" class="object-contain w-13 h-11" />
+                <img src="/tailwind.png" class="object-contain w-13 h-11" />
+                <img src="/daisy.png" class="object-contain w-9 h-12" />
             </div>
 
             <div class="text-xl lg:text-4xl lg:leading-12 justify-self-auto m-auto">


### PR DESCRIPTION
Add object-contain to logos on homepage so they don't get distorted because some are vertical, some horizontal.
before:  
<img width="301" alt="Screenshot 2025-04-11 at 1 59 26 AM" src="https://github.com/user-attachments/assets/db9ce653-9875-43b3-974d-a9be0ce3f79d" />

after:  
<img width="320" alt="Screenshot 2025-04-11 at 1 59 04 AM" src="https://github.com/user-attachments/assets/690f3e02-c1bc-4550-aa20-96b945c93490" />
